### PR TITLE
build: use meson to compile at build time instead of runtime

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,6 @@ libpatchmatch = shared_library('patchmatch',
   csrc_files,
   install : true,
   install_dir: py.get_install_dir() / 'patchmatch',
-  soversion : '0',
   dependencies: [opencv_dep])
 
 py.install_sources(['patchmatch/__init__.py', 'patchmatch/patch_match.py'], subdir: 'patchmatch')

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,25 @@
+project('patchmatch', 'cpp',
+  version : '1.0.2',
+  default_options : ['warning_level=3', 'cpp_std=c++17'])
+
+opencv_dep = dependency('opencv4', required: true)
+
+py = import('python').find_installation(pure: false)
+
+csrc_files = files(
+  'patchmatch/csrc/inpaint.cpp',
+  'patchmatch/csrc/masked_image.cpp',
+  'patchmatch/csrc/nnf.cpp',
+  'patchmatch/csrc/pyinterface.cpp'
+)
+
+
+libpatchmatch = shared_library('patchmatch',
+  csrc_files,
+  install : true,
+  install_dir: py.get_install_dir() / 'patchmatch',
+  soversion : '0',
+  dependencies: [opencv_dep])
+
+py.install_sources(['patchmatch/__init__.py', 'patchmatch/patch_match.py'], subdir: 'patchmatch')
+

--- a/patchmatch/__init__.py
+++ b/patchmatch/__init__.py
@@ -1,3 +1,3 @@
 __app_id__ = "mauwii/PyPatchMatch"
 __app_name__ = "PyPatchMatch"
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/patchmatch/patch_match.py
+++ b/patchmatch/patch_match.py
@@ -156,6 +156,8 @@ try:
             # Store patchmatch library name
             if lib_name.startswith("libpatchmatch_"):
                 pypatchmatch_lib = lib_name
+    elif "darwin" in platform_slug:
+        pypatchmatch_lib = "libpatchmatch.dylib"
 
     if pypatchmatch_lib is None:
         pypatchmatch_lib = "libpatchmatch.so"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-build-backend="setuptools.build_meta"
-requires=["setuptools == 67.1.0", "wheel"]
+build-backend = 'mesonpy'
+requires = ['meson-python']
 
 [project]
 authors=[
@@ -21,14 +21,14 @@ requires-python=">=3.9,<3.11"
 [project.urls]
 'Source Code'='https://github.com/mauwii/PyPatchMatch'
 
-[tool.setuptools.dynamic]
-version={attr="patchmatch.__version__"}
-
-[tool.setuptools.packages.find]
-include=["patchmatch", "patchmatch.csrc"]
-
-[tool.setuptools.package-data]
-"patchmatch"=['Makefile', 'csrc/*', 'travis.sh']
+# [tool.setuptools.dynamic]
+# version={attr="patchmatch.__version__"}
+#
+# [tool.setuptools.packages.find]
+# include=["patchmatch", "patchmatch.csrc"]
+#
+# [tool.setuptools.package-data]
+# "patchmatch"=['Makefile', 'csrc/*', 'travis.sh']
 
 [project.optional-dependencies]
 "dev"=["black", "flake8", "flake8-black", "isort", "pre-commit", "pylance"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,15 +21,6 @@ requires-python=">=3.9,<3.11"
 [project.urls]
 'Source Code'='https://github.com/mauwii/PyPatchMatch'
 
-# [tool.setuptools.dynamic]
-# version={attr="patchmatch.__version__"}
-#
-# [tool.setuptools.packages.find]
-# include=["patchmatch", "patchmatch.csrc"]
-#
-# [tool.setuptools.package-data]
-# "patchmatch"=['Makefile', 'csrc/*', 'travis.sh']
-
 [project.optional-dependencies]
 "dev"=["black", "flake8", "flake8-black", "isort", "pre-commit", "pylance"]
 "dist"=[


### PR DESCRIPTION
An attempt to get it to build libpatchmatch.so at build time, so it can be distributed in wheels—or when wheels aren't available, have it build at install time instead of runtime.

Notes:
- I haven't tested this with Windows, so I've left the Windows fallback code as it is.
- [ ] package version number is specified both in `__init__.py` and `meson.build`